### PR TITLE
react-scriptsのバージョンアップが必要です

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ethers": "^5.4.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^1.1.2"
   },
   "scripts": {


### PR DESCRIPTION
フォーク・クローンしてローカルで"npm run start"したらエラーが出ました。
Error: error:0308010C:digital envelope routines::unsupported

react-scriptsのバージョンを上げることで消えましたので、プルリクを発行させて頂きます。

参考にしたサイト
```
https://www.freecodecamp.org/news/error-error-0308010c-digital-envelope-routines-unsupported-node-error-solved/
```